### PR TITLE
I've updated `build.sh` to use a more general migration approach for …

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,15 +9,14 @@ pip install -r requirements.txt
 
 # Apply database migrations
 echo "Applying database migrations..."
+echo "Migrating core Django apps..."
 python manage.py migrate auth
 python manage.py migrate contenttypes
 python manage.py migrate sessions
+python manage.py migrate admin # Django admin app
 
-# Project specific apps - ensure this order is correct for your app dependencies
-python manage.py migrate adminuser # adminuser might have users, good to have it early if other apps depend on its models
-python manage.py migrate shop
-python manage.py migrate cart
-python manage.py migrate home
+echo "Migrating project apps..."
+python manage.py migrate # General migrate for all other apps
 
 # Collect static files
 echo "Collecting static files..."


### PR DESCRIPTION
…your project's applications.

Here's what I changed in `build.sh`:
- First, I'm explicitly migrating the core Django applications (auth, contenttypes, sessions, admin).
- Then, I'm using a single `python manage.py migrate` command (without specifying an app name). This allows Django to discover and apply migrations for all your remaining project-specific apps.

This approach should be more robust for handling dependencies between your apps and might help resolve issues where specific app migrations weren't being found, even if they looked correctly structured.