### PR TITLE
I've corrected the superuser creation command in the `build.sh` script.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ password = 'admin'
 email = 'admin@example.com'
 
 if not User.objects.filter(username=username).exists():
-    User.create_superuser(username, email, password)
+    User.objects.create_superuser(username, email, password)
     print(f"Superuser '{username}' created.")
 else:
     print(f"Superuser '{username}' already exists. Skipping creation.")


### PR DESCRIPTION
The script was attempting to call `User.create_superuser(...)` directly on the User model class, which caused an AttributeError.

The fix changes the call to `User.objects.create_superuser(...)`, which correctly uses the User model's manager to create the superuser. This assumes the default Django User model is being used, as `AUTH_USER_MODEL` is not set.